### PR TITLE
More general use of labels

### DIFF
--- a/src/hook/hook.go
+++ b/src/hook/hook.go
@@ -9,23 +9,25 @@ import (
 	"gopkg.in/go-playground/webhooks.v5/github"
 )
 
-// HandlePullRequestPayload processes the payload of a pull request event received
-// by the GitHub webhook. If the event's action is anothing other than
-// "labeled", which means a label has been added to the pull request, it does
-// nothing. If the action is "labeled", it loads the data of the SCS from the
-// PR's data, and iterates through the PR's labels to get its type and SCSP
-// state. If one of these two isn't defined, it does nothing more and returns.
-// If both are filled, it sends a notice through the Matrix room. If the notice
-// send fails, it returns with an error.
-// If there's more than one SCS type and/or more than one SCSP state for a SCS,
-// it returns and do nothing.
+// HandlePullRequestPayload processes the payload of a pull request event
+// received by the GitHub webhook. If the event's action is related to labels
+// (i.e. "(un)labeled"), it extracts the PR's labels' names and calls
+// handleSubmission with the list of names and some specific data regarding the
+// PR, which will then process the extracted data and trigger the generation
+// and sending of a notice to the Matrix room.
+// Returns and do nothing if the event's action isn't related to labels, or if
+// handleSubmission (or subsequent function calls) decided there was no need to
+// send a notice out.
+// Returns with an error if handleSubmission or any subsequent function call
+// returned with an error.
 func HandlePullRequestPayload(
 	pl github.PullRequestPayload, cli *matrix.Cli,
 ) (err error) {
 	// Only process the "labeled" action.
-	if pl.Action == "labeled" {
+	if pl.Action == "labeled" || pl.Action == "unlabeled" {
 		pr := pl.PullRequest
 
+		// Retrieve the labels' names.
 		labels := []string{}
 		for _, l := range pr.Labels {
 			labels = append(labels, l.Name)
@@ -37,13 +39,25 @@ func HandlePullRequestPayload(
 	return
 }
 
+// HandleIssuesPayload processes the payload of an issue event received by the
+// GitHub webhook. If the event's action is related to labels (i.e.
+// "(un)labeled"), it extracts the issue's labels' names and calls
+// handleSubmission with the list of names and some specific data regarding the
+// issue, which will then process the extracted data and trigger the generation
+// and sending of a notice to the Matrix room.
+// Returns and do nothing if the event's action isn't related to labels, or if
+// handleSubmission (or subsequent function calls) decided there was no need to
+// send a notice out.
+// Returns with an error if handleSubmission or any subsequent function call
+// returned with an error.
 func HandleIssuesPayload(
 	pl github.IssuesPayload, cli *matrix.Cli,
 ) (err error) {
-	// Only process the "labeled" action.
-	if pl.Action == "labeled" {
+	// Only process the label-related actions.
+	if pl.Action == "labeled" || pl.Action == "unlabeled" {
 		issue := pl.Issue
 
+		// Retrieve the labels' names.
 		labels := []string{}
 		for _, l := range issue.Labels {
 			labels = append(labels, l.Name)
@@ -57,6 +71,17 @@ func HandleIssuesPayload(
 	return
 }
 
+// handleSubmission uses the given data referring to a submission to decide
+// which workflow to use for the generation and sending of a Matrix notice for
+// this submission update. It implements bot the Informo SCSP
+// (https://specs.informo.network/introduction/scsp/) and a generic workflow
+// which should work with most GitHub-driven submission workflow.
+// Return and do nothing if there's too much information (i.e. more than one
+// matching label name) for the submission's type or SCSP state, as we don't
+// know what to do in this case (and the safer way to handle it is to do
+// nothing).
+// Returns with an error if either the Informo specific workflow or the generic
+// one returns with an error.
 func handleSubmission(
 	number int64, title string, url string, labels []string, cli *matrix.Cli,
 ) (err error) {
@@ -68,17 +93,24 @@ func handleSubmission(
 
 	unsplittableLabels := []string{}
 
-	for _, l := range labels {
-		// All labels defined in the SCSP follow the form "xxx:yyy", such as
-		// "xxx" is the type of information held by the label, and yyy is
-		// that information.
+	var l string
+	for _, l = range labels {
+		// All labels defined in the Informo SCSP follow the form "xxx:yyy",
+		// such as "xxx" is the type of information held by the label, and yyy
+		// is that information.
 		split := strings.Split(l, ":")
 
+		// If the label name couldn't be split, store it in a slice that will be
+		// used if either the submission's type or state couldn't be determined,
+		// and skip to the next iteration (as there's not enough data to
+		// determine a specific type or state from this label name).
 		if len(split) < 2 {
 			unsplittableLabels = append(unsplittableLabels, l)
 			continue
 		}
 
+		// Implementation of Informo's SCSP: extract the submission's type or
+		// SCSP state from the label name.
 		// "xxx" can either be "type", which is the type of the changes
 		// submitted (typo, behaviour), or "scsp", which is the SCS's SCSP
 		// state.
@@ -89,21 +121,34 @@ func handleSubmission(
 				return
 			}
 			data.Type = split[1]
-			break
 		case "scsp":
 			// If more than one SCSP state is defined, return and do noting.
 			if len(data.State) > 0 {
 				return
 			}
 			data.State = split[1]
+		default:
+			// If the first element in the split doesn't follow the Informo
+			// SCSP, it means we should process this label name with the generic
+			// workflow if we can (i.e. if a type or state can't be extracted
+			// from other label names).
+			unsplittableLabels = append(unsplittableLabels, l)
 			break
 		}
 	}
 
+	// If the submission's type or SCSP state couldn't be determined from the
+	// label names, it can either mean that the submission doesn't implement the
+	// Informo SCSP, or a list of labels implementing it will come in a future
+	// payload. To process the former case and ignore the latter, we use a
+	// generic workflow that only processes labels that couldn't be split
+	// accordingly with the Informo SCSP and for which a message string has been
+	// defined.
 	if len(data.Type) == 0 || len(data.State) == 0 {
 		return cli.SendNoticeWithUnsplitLabels(data, unsplittableLabels)
 	}
 
-	// Emit a notice to the configured Matrix room.
+	// At this point we're pretty sure the submission implements Informo's SCSP,
+	// so we use the dedicated workflow.
 	return cli.SendNoticeWithTypeAndState(data)
 }

--- a/src/hook/hook.go
+++ b/src/hook/hook.go
@@ -31,7 +31,7 @@ func HandlePullRequestPayload(
 			labels = append(labels, l.Name)
 		}
 
-		err = handleSubmission(pr.Number, pr.Title, pr.HTMLURL, labels)
+		err = handleSubmission(pr.Number, pr.Title, pr.HTMLURL, labels, cli)
 	}
 
 	return
@@ -49,14 +49,16 @@ func HandleIssuesPayload(
 			labels = append(labels, l.Name)
 		}
 
-		err = handleSubmission(issue.Number, issue.Title, issue.HTMLURL, labels)
+		err = handleSubmission(
+			issue.Number, issue.Title, issue.HTMLURL, labels, cli,
+		)
 	}
 
 	return
 }
 
 func handleSubmission(
-	number int64, title string, url string, labels []string,
+	number int64, title string, url string, labels []string, cli *matrix.Cli,
 ) (err error) {
 	data := types.SCSData{
 		Number: number,

--- a/src/hook/hook.go
+++ b/src/hook/hook.go
@@ -26,47 +26,82 @@ func HandlePullRequestPayload(
 	if pl.Action == "labeled" {
 		pr := pl.PullRequest
 
-		// Load the SCS data from the PR.
-		data := types.SCSData{
-			Number: pr.Number,
-			Title:  pr.Title,
-			URL:    pr.HTMLURL,
-		}
-
-		// Iterate through the PR's labels.
+		labels := []string{}
 		for _, l := range pr.Labels {
-			// All labels defined in the SCSP follow the form "xxx:yyy", such as
-			// "xxx" is the type of information held by the label, and yyy is
-			// that information.
-			split := strings.Split(l.Name, ":")
-
-			// "xxx" can either be "type", which is the type of the changes
-			// submitted (typo, behaviour), or "scsp", which is the SCS's SCSP
-			// state.
-			switch split[0] {
-			case "type":
-				// If more than one type is defined, return and do nothing.
-				if len(data.Type) > 0 {
-					return
-				}
-				data.Type = split[1]
-			case "scsp":
-				// If more than one SCSP state is defined, return and do noting.
-				if len(data.State) > 0 {
-					return
-				}
-				data.State = split[1]
-			}
+			labels = append(labels, l.Name)
 		}
 
-		// Check if both the type and SCSP state are defined.
-		if len(data.Type) == 0 || len(data.State) == 0 {
-			return
-		}
-
-		// Emit a notice to the configured Matrix room.
-		err = cli.SendNotice(data)
+		err = handleSubmission(pr.Number, pr.Title, pr.HTMLURL, labels)
 	}
 
 	return
+}
+
+func HandleIssuesPayload(
+	pl github.IssuesPayload, cli *matrix.Cli,
+) (err error) {
+	// Only process the "labeled" action.
+	if pl.Action == "labeled" {
+		issue := pl.Issue
+
+		labels := []string{}
+		for _, l := range issue.Labels {
+			labels = append(labels, l.Name)
+		}
+
+		err = handleSubmission(issue.Number, issue.Title, issue.HTMLURL, labels)
+	}
+
+	return
+}
+
+func handleSubmission(
+	number int64, title string, url string, labels []string,
+) (err error) {
+	data := types.SCSData{
+		Number: number,
+		Title:  title,
+		URL:    url,
+	}
+
+	unsplittableLabels := []string{}
+
+	for _, l := range labels {
+		// All labels defined in the SCSP follow the form "xxx:yyy", such as
+		// "xxx" is the type of information held by the label, and yyy is
+		// that information.
+		split := strings.Split(l, ":")
+
+		if len(split) < 2 {
+			unsplittableLabels = append(unsplittableLabels, l)
+			continue
+		}
+
+		// "xxx" can either be "type", which is the type of the changes
+		// submitted (typo, behaviour), or "scsp", which is the SCS's SCSP
+		// state.
+		switch split[0] {
+		case "type":
+			// If more than one type is defined, return and do nothing.
+			if len(data.Type) > 0 {
+				return
+			}
+			data.Type = split[1]
+			break
+		case "scsp":
+			// If more than one SCSP state is defined, return and do noting.
+			if len(data.State) > 0 {
+				return
+			}
+			data.State = split[1]
+			break
+		}
+	}
+
+	if len(data.Type) == 0 || len(data.State) == 0 {
+		return cli.SendNoticeWithUnsplitLabels(data, unsplittableLabels)
+	}
+
+	// Emit a notice to the configured Matrix room.
+	return cli.SendNoticeWithTypeAndState(data)
 }

--- a/src/matrix/matrix.go
+++ b/src/matrix/matrix.go
@@ -60,7 +60,7 @@ func (c *Cli) SendNoticeWithUnsplitLabels(
 ) (err error) {
 	var ok bool
 	for _, l := range unsplitLabels {
-		if len(data.Message) > 0 && _, ok = c.cfg.Notices.Strings["global"][l]; ok {
+		if _, ok = c.cfg.Notices.Strings["global"][l]; ok && len(data.Message) > 0 {
 			return
 		}
 

--- a/src/scs-bot/main.go
+++ b/src/scs-bot/main.go
@@ -58,6 +58,7 @@ func main() {
 			return
 		}
 
+		// Handle both issues and pull requests payloads.
 		switch payload.(type) {
 		case github.PullRequestPayload:
 			err = hook.HandlePullRequestPayload(
@@ -71,6 +72,8 @@ func main() {
 			break
 		}
 
+		// If any of the handler or workflow returned with an error, log it and
+		// tell the user something went wrong.
 		if err != nil {
 			fmt.Println(err)
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Currently WIP.

Changes involve support for a more general use of labels, thus making the bot able to track submissions on other projects, e.g. the Matrix specs, alongside implementing [Informo's SCSP](https://specs.informo.network/introduction/scsp/).

Current status: the code is here, all that's left to to is test it and document it.