### PR TITLE
Improve event handling and parallelisation

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -33,3 +33,12 @@ notices:
   pattern: "SCS #{{ .Number }} \"{{ .Title }}\" {{ .Message }}: {{ .URL }}"
   # IDs of the Matrix rooms to send notices to.
   rooms: ["!someid:example.com"]
+
+# Settings for connecting to the database.
+database:
+  # Database driver. Can be either "postgres" or "sqlite3".
+  driver: sqlite3
+  # Data source, which is the connection string for postgres or the database's
+  # location for sqlite3.
+  # Examples for postgres (look for "connStr"): https://godoc.org/github.com/lib/pq
+  data_source: ./specs-bot.db

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -2,16 +2,29 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 
 	"gopkg.in/yaml.v2"
 )
 
+var supportedDBDrivers = map[string]bool{
+	"postgres": true,
+	"sqlite":   true,
+}
+
+var (
+	// ErrUnsupportedDBDriver is returned if the driver name in the configuration
+	// file doesn't refer to a supported database driver.
+	ErrUnsupportedDBDriver = fmt.Errorf("Unsupported database driver, only \"postgres\" and \"sqlite\" are supported")
+)
+
 // Config represents the top-level structure of the configuration file.
 type Config struct {
-	Matrix  MatrixConfig  `yaml:"matrix"`
-	Webhook WebhookConfig `yaml:"webhook"`
-	Notices NoticesConfig `yaml:"notices"`
+	Matrix   MatrixConfig   `yaml:"matrix"`
+	Webhook  WebhookConfig  `yaml:"webhook"`
+	Notices  NoticesConfig  `yaml:"notices"`
+	Database DatabaseConfig `yaml:"database"`
 }
 
 // MatrixConfig represents the Matrix part of the configuration file.
@@ -38,6 +51,12 @@ type NoticesConfig struct {
 	Strings         map[string]map[string]string
 }
 
+// DatabaseConfig represents the database part of the configuration file.
+type DatabaseConfig struct {
+	Driver     string `yaml:"driver"`
+	DataSource string `yaml:"data_source"`
+}
+
 // Load reads the configuration file located at the provided path, and fills the
 // properties of an instance of the Config structure with its content. It also
 // loads the strings from the notices strings JSON file by parsing it.
@@ -58,7 +77,14 @@ func Load(filePath string) (cfg *Config, err error) {
 		return
 	}
 
-	err = json.Unmarshal(strings, &(cfg.Notices.Strings))
+	if err = json.Unmarshal(strings, &(cfg.Notices.Strings)); err != nil {
+		return
+	}
+
+	if _, supported := supportedDBDrivers[cfg.Database.Driver]; !supported {
+		err = ErrUnsupportedDBDriver
+		return
+	}
 
 	return
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -10,13 +10,13 @@ import (
 
 var supportedDBDrivers = map[string]bool{
 	"postgres": true,
-	"sqlite":   true,
+	"sqlite3":  true,
 }
 
 var (
 	// ErrUnsupportedDBDriver is returned if the driver name in the configuration
 	// file doesn't refer to a supported database driver.
-	ErrUnsupportedDBDriver = fmt.Errorf("Unsupported database driver, only \"postgres\" and \"sqlite\" are supported")
+	ErrUnsupportedDBDriver = fmt.Errorf("Unsupported database driver, only \"postgres\" and \"sqlite3\" are supported")
 )
 
 // Config represents the top-level structure of the configuration file.

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -81,6 +81,7 @@ func Load(filePath string) (cfg *Config, err error) {
 		return
 	}
 
+	// Check if the configured database driver is supported.
 	if _, supported := supportedDBDrivers[cfg.Database.Driver]; !supported {
 		err = ErrUnsupportedDBDriver
 		return

--- a/src/database/database.go
+++ b/src/database/database.go
@@ -1,0 +1,49 @@
+package database
+
+import (
+	"database/sql"
+
+	"config"
+
+	// Database drivers
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Database represents the crawler's database.
+type Database struct {
+	db            *sql.DB
+	proposalState proposalStateStatements
+}
+
+// NewDatabase creates a new instance of the Database structure by opening a
+// PostgreSQL database accessible using a given connexion configuration string,
+// and preparing the different statements used.
+// Returns an error if there was an issue opening the database or preparing the
+// different statements.
+func NewDatabase(cfg *config.Config) (database *Database, err error) {
+	database = new(Database)
+
+	if database.db, err = sql.Open(cfg.Database.Driver, cfg.Database.DataSource); err != nil {
+		return
+	}
+	if err = database.proposalState.prepare(database.db); err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateProposalState updates the state of a proposal, or inserts it if there's
+// no saved state for this proposal.
+// Returns an error if we couldn't talk to the database.
+func (d *Database) UpdateProposalState(number int64, labels []string) error {
+	return d.proposalState.upsertState(number, labels)
+}
+
+// GetProposalState retrieves the state of a proposal. Returns an empty slice if
+// no state has been saved for this proposal.
+// Returns an error if we couldn't talk to the database.
+func (d *Database) GetProposalState(number int64) ([]string, error) {
+	return d.proposalState.selectState(number)
+}

--- a/src/database/database.go
+++ b/src/database/database.go
@@ -8,6 +8,8 @@ import (
 	// Database drivers
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Database represents the crawler's database.
@@ -38,6 +40,10 @@ func NewDatabase(cfg *config.Config) (database *Database, err error) {
 // no saved state for this proposal.
 // Returns an error if we couldn't talk to the database.
 func (d *Database) UpdateProposalState(number int64, labels []string) error {
+	logrus.WithFields(logrus.Fields{
+		"number": number,
+		"labels": labels,
+	}).Debug("Updating proposal state")
 	return d.proposalState.upsertState(number, labels)
 }
 
@@ -45,5 +51,8 @@ func (d *Database) UpdateProposalState(number int64, labels []string) error {
 // no state has been saved for this proposal.
 // Returns an error if we couldn't talk to the database.
 func (d *Database) GetProposalState(number int64) ([]string, error) {
+	logrus.WithFields(logrus.Fields{
+		"number": number,
+	}).Debug("Retrieving proposal state")
 	return d.proposalState.selectState(number)
 }

--- a/src/database/proposal_state_table.go
+++ b/src/database/proposal_state_table.go
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS proposal_state (
 	-- Numeric identifier of the proposal, i.e. the issue/PR's numeric ID
 	number INTEGER PRIMARY KEY,
 	-- Comma-separated list of labels, in the latest state of the proposal we know about.
-	labels TEXT NOT NULL,
+	labels TEXT NOT NULL
 );
 `
 

--- a/src/database/proposal_state_table.go
+++ b/src/database/proposal_state_table.go
@@ -1,0 +1,71 @@
+package database
+
+import (
+	"database/sql"
+	"strings"
+)
+
+const sep = ","
+
+// Schema of the table.
+const proposalStateSchema = `
+-- Store proposal states
+CREATE TABLE IF NOT EXISTS proposal_state (
+	-- Numeric identifier of the proposal, i.e. the issue/PR's numeric ID
+	number INTEGER PRIMARY KEY,
+	-- Comma-separated list of labels, in the latest state of the proposal we know about.
+	labels TEXT NOT NULL,
+);
+`
+
+const upsertStateSQL = `
+	INSERT INTO proposal_state (number, labels) VALUES ($1, $2)
+	ON CONFLICT (number) DO UPDATE SET labels = $2
+`
+
+const selectStateSQL = `
+	SELECT labels FROM proposal_state WHERE number = $1
+`
+
+type proposalStateStatements struct {
+	upsertStateStmt *sql.Stmt
+	selectStateStmt *sql.Stmt
+}
+
+// Create the table if it doesn't exist and prepare the SQL statements.
+func (ps *proposalStateStatements) prepare(db *sql.DB) (err error) {
+	_, err = db.Exec(proposalStateSchema)
+	if err != nil {
+		return
+	}
+	if ps.upsertStateStmt, err = db.Prepare(upsertStateSQL); err != nil {
+		return
+	}
+	if ps.selectStateStmt, err = db.Prepare(selectStateSQL); err != nil {
+		return
+	}
+	return
+}
+
+// upsertState updates the state of a proposal, or inserts it if there's no
+// saved state for this proposal.
+// Returns an error if we couldn't talk to the database.
+func (ps *proposalStateStatements) upsertState(number int64, labels []string) error {
+	_, err := ps.upsertStateStmt.Exec(number, strings.Join(labels, sep))
+	return err
+}
+
+// selectState retrieves the state of a proposal. Returns an empty slice if no
+// state has been saved for this proposal.
+// Returns an error if we couldn't talk to the database.
+func (ps *proposalStateStatements) selectState(number int64) ([]string, error) {
+	var s string
+
+	if err := ps.selectStateStmt.QueryRow(number).Scan(&s); err == sql.ErrNoRows {
+		return make([]string, 0), nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(s, sep), nil
+}

--- a/src/hook/hook.go
+++ b/src/hook/hook.go
@@ -44,8 +44,10 @@ func HandlePullRequestPayload(
 		}
 
 		// Retrieve the labels' names.
-		labels := []string{}
+		labels := make([]string, 0)
+		newState := make([]string, 0)
 		for _, l := range pr.Labels {
+			newState = append(labels, l.Name)
 			if _, exists := state[l.Name]; !exists {
 				labels = append(labels, l.Name)
 			}
@@ -56,7 +58,7 @@ func HandlePullRequestPayload(
 		}
 
 		// Update the proposal's state in the database.
-		err = db.UpdateProposalState(pr.Number, labels)
+		err = db.UpdateProposalState(pr.Number, newState)
 		return unlockAndReturnErr(pr.Number, err)
 	}
 
@@ -95,8 +97,10 @@ func HandleIssuesPayload(
 		}
 
 		// Retrieve the labels' names.
-		labels := []string{}
+		labels := make([]string, 0)
+		newState := make([]string, 0)
 		for _, l := range issue.Labels {
+			newState = append(labels, l.Name)
 			if _, exists := state[l.Name]; !exists {
 				labels = append(labels, l.Name)
 			}
@@ -109,7 +113,7 @@ func HandleIssuesPayload(
 		}
 
 		// Update the proposal's state in the database.
-		err = db.UpdateProposalState(issue.Number, labels)
+		err = db.UpdateProposalState(issue.Number, newState)
 		return unlockAndReturnErr(issue.Number, err)
 	}
 

--- a/src/hook/hook.go
+++ b/src/hook/hook.go
@@ -35,6 +35,7 @@ func HandlePullRequestPayload(
 		// Lock the mutex for this proposal in order to make sure it doesn't get
 		// updated by another event before we're done with this one.
 		mutex.Lock(pr.Number)
+		logrus.WithField("number", pr.Number).Debug("Locked mutex")
 
 		// Retrieve the proposal's state.
 		state, err := getState(db, pr.Number)
@@ -85,6 +86,7 @@ func HandleIssuesPayload(
 		// Lock the mutex for this proposal in order to make sure it doesn't get
 		// updated by another event before we're done with this one.
 		mutex.Lock(issue.Number)
+		logrus.WithField("number", issue.Number).Debug("Locked mutex")
 
 		// Retrieve the proposal's state.
 		state, err := getState(db, issue.Number)
@@ -221,6 +223,9 @@ func handleSubmission(
 	return cli.SendNoticeWithTypeAndState(data)
 }
 
+// getState retrieves the state of a given proposal from the database and
+// converts it into a map.
+// Returns an error if the database driver returns one.
 func getState(db *database.Database, number int64) (map[string]bool, error) {
 	// Retrieve the proposal's state.
 	state, err := db.GetProposalState(number)
@@ -238,7 +243,10 @@ func getState(db *database.Database, number int64) (map[string]bool, error) {
 	return stateMap, nil
 }
 
+// unlockAndReturnErr unlocks the mutex for a given proposal and returns with a
+// given error.
 func unlockAndReturnErr(number int64, err error) error {
 	mutex.Unlock(number)
+	logrus.WithField("number", number).Debug("Unlocked mutex")
 	return err
 }

--- a/src/hook/hook.go
+++ b/src/hook/hook.go
@@ -47,7 +47,7 @@ func HandlePullRequestPayload(
 		labels := make([]string, 0)
 		newState := make([]string, 0)
 		for _, l := range pr.Labels {
-			newState = append(labels, l.Name)
+			newState = append(newState, l.Name)
 			if _, exists := state[l.Name]; !exists {
 				labels = append(labels, l.Name)
 			}
@@ -100,7 +100,7 @@ func HandleIssuesPayload(
 		labels := make([]string, 0)
 		newState := make([]string, 0)
 		for _, l := range issue.Labels {
-			newState = append(labels, l.Name)
+			newState = append(newState, l.Name)
 			if _, exists := state[l.Name]; !exists {
 				labels = append(labels, l.Name)
 			}

--- a/src/hook/hook.go
+++ b/src/hook/hook.go
@@ -54,6 +54,7 @@ func HandlePullRequestPayload(
 			return unlockAndReturnErr(pr.Number, err)
 		}
 
+		// Update the proposal's state in the database.
 		err = db.UpdateProposalState(pr.Number, labels)
 		return unlockAndReturnErr(pr.Number, err)
 	}
@@ -105,6 +106,7 @@ func HandleIssuesPayload(
 			return unlockAndReturnErr(issue.Number, err)
 		}
 
+		// Update the proposal's state in the database.
 		err = db.UpdateProposalState(issue.Number, labels)
 		return unlockAndReturnErr(issue.Number, err)
 	}
@@ -135,7 +137,7 @@ func handleSubmission(
 
 	logDebugEntry.Debug("Handling submission")
 
-	data := types.SCSData{
+	data := &types.SCSData{
 		Number: number,
 		Title:  title,
 		URL:    url,

--- a/src/mutex/mutex.go
+++ b/src/mutex/mutex.go
@@ -1,0 +1,27 @@
+package mutex
+
+import (
+	"sync"
+)
+
+var mutexes = make(map[int64]*sync.Mutex)
+
+// Lock locks the mutex for a given proposal, after instanciating if it doesn't
+// exist.
+func Lock(number int64) {
+	// Lock the existing mutex if there's one.
+	if m, exists := mutexes[number]; exists {
+		m.Lock()
+		return
+	}
+
+	// If there's no mutex for this proposal, create one then lock it.
+	mutexes[number] = new(sync.Mutex)
+	mutexes[number].Lock()
+}
+
+// Unlock unlocks the mutex for a given proposal.
+// Panics if the mutex doesn't exist.
+func Unlock(number int64) {
+	mutexes[number].Unlock()
+}

--- a/src/specs-bot/main.go
+++ b/src/specs-bot/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"config"
+	"database"
 	"hook"
 	"matrix"
 
@@ -40,6 +41,12 @@ func main() {
 	}
 	logrus.Debug("Matrix client instantiated")
 
+	// Instantiate the database and prepare statements.
+	db, err := database.NewDatabase(cfg)
+	if err != nil {
+		logrus.Panic(err)
+	}
+
 	// Instantiate a GitHub webhook.
 	h, err := github.New(github.Options.Secret(cfg.Webhook.Secret))
 	if err != nil {
@@ -69,12 +76,12 @@ func main() {
 		switch payload.(type) {
 		case github.PullRequestPayload:
 			err = hook.HandlePullRequestPayload(
-				payload.(github.PullRequestPayload), cli,
+				payload.(github.PullRequestPayload), cli, db,
 			)
 			break
 		case github.IssuesPayload:
 			err = hook.HandleIssuesPayload(
-				payload.(github.IssuesPayload), cli,
+				payload.(github.IssuesPayload), cli, db,
 			)
 			break
 		}

--- a/src/specs-bot/main.go
+++ b/src/specs-bot/main.go
@@ -46,6 +46,7 @@ func main() {
 	if err != nil {
 		logrus.Panic(err)
 	}
+	logrus.Debug("Database instantiated")
 
 	// Instantiate a GitHub webhook.
 	h, err := github.New(github.Options.Secret(cfg.Webhook.Secret))

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -10,3 +10,19 @@ type SCSData struct {
 	Message string
 	URL     string
 }
+
+// CopyWithMsg returns a new instance of SCSData with the given string as its
+// Message field.
+func (d *SCSData) CopyWithMsg(msg string) *SCSData {
+	newData := new(SCSData)
+
+	newData.Number = d.Number
+	newData.Title = d.Title
+	newData.Type = d.Type
+	newData.State = d.State
+	newData.URL = d.URL
+
+	newData.Message = msg
+
+	return newData
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -22,9 +22,21 @@
 			"path": "/query"
 		},
 		{
+			"importpath": "github.com/lib/pq",
+			"repository": "https://github.com/lib/pq",
+			"revision": "9eb73efc1fcc404148b56765b0d3f61d9a5ef8ee",
+			"branch": "master"
+		},
+		{
 			"importpath": "github.com/matrix-org/gomatrix",
 			"repository": "https://github.com/matrix-org/gomatrix",
 			"revision": "eb6a57bae949723df0d4947a03d4136a1f64b784",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/mattn/go-sqlite3",
+			"repository": "https://github.com/mattn/go-sqlite3",
+			"revision": "87ac1cb49789a0ef6b0d7be6b7aa458a9b90d7ae",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
Use state tracking (using database) and mutexes to make sure we:

* Only process added labels
* Don't process more than one event at a time

Also changes the generic workflow so that multiple matching added labels generate as many notices being sent.

Fixes #3 