### PR TITLE
Add global lock to avoid multiple goroutines using the mutexes map at the same time

### DIFF
--- a/src/mutex/mutex.go
+++ b/src/mutex/mutex.go
@@ -5,15 +5,16 @@ import (
 )
 
 var (
-	mutexes = make(map[int64]*sync.Mutex)
-	lock    = new(sync.Mutex)
+	mutexes  = make(map[int64]*sync.Mutex)
+	mapMutex = new(sync.Mutex)
 )
 
 // Lock locks the mutex for a given proposal, after instanciating if it doesn't
 // exist.
 func Lock(number int64) {
 	// Avoid multiple goroutines using the map at the same time.
-	lock.Lock()
+	mapMutex.Lock()
+	defer mapMutex.Unlock()
 
 	// Lock the existing mutex if there's one.
 	if m, exists := mutexes[number]; exists {
@@ -24,15 +25,13 @@ func Lock(number int64) {
 	// If there's no mutex for this proposal, create one then lock it.
 	mutexes[number] = new(sync.Mutex)
 	mutexes[number].Lock()
-
-	lock.Unlock()
 }
 
 // Unlock unlocks the mutex for a given proposal.
 // Panics if the mutex doesn't exist.
 func Unlock(number int64) {
 	// Avoid multiple goroutines using the map at the same time.
-	lock.Lock()
+	mapMutex.Lock()
 	mutexes[number].Unlock()
-	lock.Unlock()
+	mapMutex.Unlock()
 }

--- a/src/mutex/mutex.go
+++ b/src/mutex/mutex.go
@@ -32,6 +32,7 @@ func Lock(number int64) {
 func Unlock(number int64) {
 	// Avoid multiple goroutines using the map at the same time.
 	mapMutex.Lock()
+	defer mapMutex.Unlock()
+
 	mutexes[number].Unlock()
-	mapMutex.Unlock()
 }

--- a/src/mutex/mutex.go
+++ b/src/mutex/mutex.go
@@ -4,11 +4,17 @@ import (
 	"sync"
 )
 
-var mutexes = make(map[int64]*sync.Mutex)
+var (
+	mutexes = make(map[int64]*sync.Mutex)
+	lock    = new(sync.Mutex)
+)
 
 // Lock locks the mutex for a given proposal, after instanciating if it doesn't
 // exist.
 func Lock(number int64) {
+	// Avoid multiple goroutines using the map at the same time.
+	lock.Lock()
+
 	// Lock the existing mutex if there's one.
 	if m, exists := mutexes[number]; exists {
 		m.Lock()
@@ -18,10 +24,15 @@ func Lock(number int64) {
 	// If there's no mutex for this proposal, create one then lock it.
 	mutexes[number] = new(sync.Mutex)
 	mutexes[number].Lock()
+
+	lock.Unlock()
 }
 
 // Unlock unlocks the mutex for a given proposal.
 // Panics if the mutex doesn't exist.
 func Unlock(number int64) {
+	// Avoid multiple goroutines using the map at the same time.
+	lock.Lock()
 	mutexes[number].Unlock()
+	lock.Unlock()
 }


### PR DESCRIPTION
Fixes #7 