### PR TITLE
Fix a deadlock preventing events from being processed

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -26,16 +26,23 @@ import (
 func HandlePullRequestPayload(
 	pl github.PullRequestPayload, cli *matrix.Cli, db *database.Database,
 ) (err error) {
-	logrus.WithField("action", pl.Action).Debug("Got PR event payload")
+	logrus.WithFields(logrus.Fields{
+		"action": pl.Action,
+		"number": pl.PullRequest.Number,
+	}).Debug("Got PR event payload")
 
 	// Only process the label-related action.
 	if pl.Action == "labeled" || pl.Action == "unlabeled" {
+		logrus.WithFields(logrus.Fields{
+			"action": pl.Action,
+			"number": pl.PullRequest.Number,
+		}).Debug("Processing PR")
+
 		pr := pl.PullRequest
 
 		// Lock the mutex for this proposal in order to make sure it doesn't get
 		// updated by another event before we're done with this one.
 		mutex.Lock(pr.Number)
-		logrus.WithField("number", pr.Number).Debug("Locked mutex")
 
 		// Retrieve the labels' names.
 		labels := make([]string, 0)
@@ -46,6 +53,11 @@ func HandlePullRequestPayload(
 		err = handleSubmission(pr.Number, pr.Title, pr.HTMLURL, labels, cli, db)
 		return unlockAndReturnErr(pr.Number, err)
 	}
+
+	logrus.WithFields(logrus.Fields{
+		"action": pl.Action,
+		"number": pl.PullRequest.Number,
+	}).Debug("Ignoring PR")
 
 	return nil
 }
@@ -64,16 +76,23 @@ func HandlePullRequestPayload(
 func HandleIssuesPayload(
 	pl github.IssuesPayload, cli *matrix.Cli, db *database.Database,
 ) (err error) {
-	logrus.WithField("action", pl.Action).Debug("Got issue event payload")
+	logrus.WithFields(logrus.Fields{
+		"action": pl.Action,
+		"number": pl.Issue.Number,
+	}).Debug("Got issue event payload")
 
 	// Only process the label-related actions.
 	if pl.Action == "labeled" || pl.Action == "unlabeled" {
+		logrus.WithFields(logrus.Fields{
+			"action": pl.Action,
+			"number": pl.Issue.Number,
+		}).Debug("Processing issue")
+
 		issue := pl.Issue
 
 		// Lock the mutex for this proposal in order to make sure it doesn't get
 		// updated by another event before we're done with this one.
 		mutex.Lock(issue.Number)
-		logrus.WithField("number", issue.Number).Debug("Locked mutex")
 
 		// Retrieve the labels' names.
 		labels := make([]string, 0)
@@ -86,6 +105,11 @@ func HandleIssuesPayload(
 		)
 		return unlockAndReturnErr(issue.Number, err)
 	}
+
+	logrus.WithFields(logrus.Fields{
+		"action": pl.Action,
+		"number": pl.Issue.Number,
+	}).Debug("Ignoring issue")
 
 	return nil
 }

--- a/mutex/mutex.go
+++ b/mutex/mutex.go
@@ -2,6 +2,8 @@ package mutex
 
 import (
 	"sync"
+
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -9,30 +11,50 @@ var (
 	mapMutex = new(sync.Mutex)
 )
 
-// Lock locks the mutex for a given proposal, after instanciating if it doesn't
+// Lock locks the mutex for a given proposal, after instantiating if it doesn't
 // exist.
 func Lock(number int64) {
 	// Avoid multiple goroutines using the map at the same time.
+	logrus.Debug("Getting a lock on the global mutex")
 	mapMutex.Lock()
-	defer mapMutex.Unlock()
+	logrus.Debug("Got a lock on the global mutex")
 
-	// Lock the existing mutex if there's one.
-	if m, exists := mutexes[number]; exists {
-		m.Lock()
-		return
+	// Retrieve the mutex for this number from the map, or create one if none exist.
+	m, exists := mutexes[number]
+	if !exists {
+		m = new(sync.Mutex)
+		mutexes[number] = m
 	}
 
-	// If there's no mutex for this proposal, create one then lock it.
-	mutexes[number] = new(sync.Mutex)
-	mutexes[number].Lock()
+	// Don't keep the global mutex locked if no more access to the map is needed.
+	mapMutex.Unlock()
+	logrus.Debug("Unlocked the global mutex")
+
+	// Lock the mutex for this number.
+	logrus.WithField("number", number).Debugf("Getting a lock on the mutex at address %p", m)
+	m.Lock()
+	logrus.WithField("number", number).Debugf("Got a lock on the mutex at address %p", m)
 }
 
 // Unlock unlocks the mutex for a given proposal.
-// Panics if the mutex doesn't exist.
+// Does nothing if the mutex doesn't exist.
 func Unlock(number int64) {
 	// Avoid multiple goroutines using the map at the same time.
+	logrus.Debug("Getting a lock on the global mutex")
 	mapMutex.Lock()
-	defer mapMutex.Unlock()
+	logrus.Debug("Got a lock on the global mutex")
 
-	mutexes[number].Unlock()
+	// Retrieve the mutex for this number from the map, if one exists.
+	m, exists := mutexes[number]
+
+	// Don't keep the global mutex locked if no more access to the map is needed.
+	mapMutex.Unlock()
+	logrus.Debug("Unlocked the global mutex")
+
+	// Unlock the mutex for this number if one exists (otherwise we can safely ignore it).
+	if exists {
+		logrus.WithField("number", number).Debugf("Unlocking the mutex at address %p", m)
+		m.Unlock()
+		logrus.WithField("number", number).Debugf("Unlocked the mutex at address %p", m)
+	}
 }


### PR DESCRIPTION
The bot has a mutex per issue/PR that ensures no more than one payload is processed at the same time for the same issue/PR. These mutexes are stored in a map. To prevent concurrent accesses to the map, the global `mapMutex` mutex is used. However, the bot only unlocks it once it's done doing stuff with the mutex it got from the map, which can cause deadlocks.

If we get two requests (`r1` and `r2`) with either the labeled or the unlabeled action for the same issue/PR at the same time (which happens if, e.g. one adds two labels at the same time to the same issue/PR before closing the labels UI in GitHub), then:

* `r1` comes in, locks the `mapMutex`, locks the issue's/PR's mutex, unlocks the `mapMutex`, then does its stuff
* `r2` comes in, locks the `mapMutex`, and wait till the issue's/PR's mutex is
* `r1` finishes its stuff, thus goes to unlock the issue's/PR's mutex
* `r1` waits forever, since it needs to unlock the `mapMutex` for that, which is already locked by `r2`
* `r2` never releases the `mapMutex` since it only does after it's locked the issue's/PR's mutex, which it can't do because it's waiting on r1 to unlock it

And so `r2` waits on `r1` which is itself waiting on `r2`, i.e. there's a deadlock. It then prevents any request from ever getting a lock on the `mapMutex` because `r2` will never release it.

This patch fixes this deadlock issue by unlocking the `mapMutex` right after any access to the map, instead of waiting for the operation on the issue's/PR's mutex to finish.

It also includes some more debug logging so that one can better know what happens to each mutex when looking at the logs.

It also prevents the `Unlock` function from `panic`ing if given a number for which it doesn't have a mutex, because that's the safest thing to do when running the bot in production imho.